### PR TITLE
refactor: removed the limits on the length of telegram and discord lines

### DIFF
--- a/src/modules/EditProfile/index.tsx
+++ b/src/modules/EditProfile/index.tsx
@@ -117,7 +117,7 @@ export const EditProfile: FC = () => {
               required: 'This is required.',
               pattern: {
                 value: /^[A-Za-z]+$/i,
-                message: 'This input is letters only.',
+                message: 'This input is latin letters only.',
               },
               minLength: {
                 value: 3,
@@ -140,7 +140,7 @@ export const EditProfile: FC = () => {
               required: 'This is required.',
               pattern: {
                 value: /^[A-Za-z]+$/i,
-                message: 'This input is letters only.',
+                message: 'This input is latin letters only.',
               },
               minLength: {
                 value: 3,
@@ -162,12 +162,16 @@ export const EditProfile: FC = () => {
             register={register({
               required: 'This is required.',
               pattern: {
-                value: /^[A-Za-z0-9]+$/i,
-                message: 'This input is letters and digits only.',
+                value: /^[A-Za-z0-9@#_]+$/i,
+                message: 'This input is latin letters and digits only.',
               },
               minLength: {
                 value: 3,
                 message: 'minimal length is 3',
+              },
+              maxLength: {
+                value: 50,
+                message: 'This input exceed maxLength.',
               },
             })}
           />
@@ -181,12 +185,16 @@ export const EditProfile: FC = () => {
             register={register({
               required: 'This is required.',
               pattern: {
-                value: /^[A-Za-z0-9]+$/i,
-                message: 'This input is letters and digits only.',
+                value: /^[A-Za-z0-9@_]+$/i,
+                message: 'This input is latin letters and digits only.',
               },
               minLength: {
                 value: 3,
                 message: 'minimal length is 3',
+              },
+              maxLength: {
+                value: 50,
+                message: 'This input exceed maxLength.',
               },
             })}
           />
@@ -201,7 +209,7 @@ export const EditProfile: FC = () => {
               required: 'This is required.',
               pattern: {
                 value: /^[A-Za-z]+$/i,
-                message: 'This input is letters only.',
+                message: 'This input is latin letters only.',
               },
               minLength: {
                 value: 3,
@@ -224,7 +232,7 @@ export const EditProfile: FC = () => {
               required: 'This is required.',
               pattern: {
                 value: /^[A-Za-z]+$/i,
-                message: 'This input is letters only.',
+                message: 'This input is latin letters only.',
               },
               minLength: {
                 value: 3,

--- a/src/modules/EditProfile/index.tsx
+++ b/src/modules/EditProfile/index.tsx
@@ -169,10 +169,6 @@ export const EditProfile: FC = () => {
                 value: 3,
                 message: 'minimal length is 3',
               },
-              maxLength: {
-                value: 12,
-                message: 'This input exceed maxLength.',
-              },
             })}
           />
           <InputField
@@ -191,10 +187,6 @@ export const EditProfile: FC = () => {
               minLength: {
                 value: 3,
                 message: 'minimal length is 3',
-              },
-              maxLength: {
-                value: 12,
-                message: 'This input exceed maxLength.',
               },
             })}
           />

--- a/src/modules/EditProfile/index.tsx
+++ b/src/modules/EditProfile/index.tsx
@@ -208,7 +208,7 @@ export const EditProfile: FC = () => {
             register={register({
               required: 'This is required.',
               pattern: {
-                value: /^[A-Za-z]+$/i,
+                value: /^[A-Za-z\-]+$/i,
                 message: 'This input is latin letters only.',
               },
               minLength: {
@@ -231,7 +231,7 @@ export const EditProfile: FC = () => {
             register={register({
               required: 'This is required.',
               pattern: {
-                value: /^[A-Za-z]+$/i,
+                value: /^[A-Za-z\-]+$/i,
                 message: 'This input is latin letters only.',
               },
               minLength: {


### PR DESCRIPTION
Верхние лимиты для телеграма и дискорда выставил в 30.
Добавил в разрешенные символы @#_
Добавил пояснение, что следует использовать латинские символы в имени и названии страны.
В стране и городе можно использовать дефис

