### PR TITLE
RSSFE-39 fix: fix sending data with spaces

### DIFF
--- a/src/modules/EditProfile/formFields.ts
+++ b/src/modules/EditProfile/formFields.ts
@@ -128,7 +128,7 @@ export const formFields: InputFieldProps[] = [
     register: {
       required: 'This is required.',
       pattern: {
-        value: /^[0-9]+$/i,
+        value: /^[1-9]+\d*$/i,
         message: 'This input is number only.',
       },
       minLength: {

--- a/src/modules/EditProfile/formFields.ts
+++ b/src/modules/EditProfile/formFields.ts
@@ -48,7 +48,7 @@ export const formFields: InputFieldProps[] = [
     register: {
       required: 'This is required.',
       pattern: {
-        value: /^[A-Za-z0-9@#_() ]+$/i,
+        value: /^[A-Za-z0-9@#-_() ]+$/i,
         message: 'This input is letters and digits only.',
       },
       minLength: {
@@ -68,7 +68,7 @@ export const formFields: InputFieldProps[] = [
     register: {
       required: 'This is required.',
       pattern: {
-        value: /^[A-Za-z0-9_]+$/i,
+        value: /^[A-Za-z0-9-_ ]+$/i,
         message: 'This input is letters and digits only.',
       },
       minLength: {

--- a/src/modules/EditProfile/index.tsx
+++ b/src/modules/EditProfile/index.tsx
@@ -90,7 +90,7 @@ export const EditProfile: FC = () => {
     const { name, value } = e.target;
     setInputValues({
       ...inputValues,
-      [name]: value,
+      [name]: value.trim(),
     });
   };
 


### PR DESCRIPTION
Close #115 
Fixed sending data without spaces in edit profile inputs
User can enter information with spaces but data will be sent to server without them
+ Allowed "-" in tg and discord inputs